### PR TITLE
Only fields with errors are highlighted instead of highlighting all the fields when there is an error.

### DIFF
--- a/app/views/simple_contact/contact/new.html.erb
+++ b/app/views/simple_contact/contact/new.html.erb
@@ -26,14 +26,14 @@
           <% end %>
 
           <%# Message fields below %>
-          <div class="form-group <%= 'has-error' if @message.errors.present? %>">
+          <div class="form-group <%= 'has-error' if @message.errors.include?(:name) %>">
             <%= f.label :name, t(:email_name_label).html_safe, class: "col-xs-2 control-label" %>
             <div class="col-xs-10">
               <%= f.text_field :name, placeholder: t(:email_name_placeholder).html_safe, class: "form-control" %>
             </div>
           </div>
 
-          <div class="form-group <%= 'has-error' if @message.errors.present? %>">
+          <div class="form-group <%= 'has-error' if @message.errors.include?(:email) %>">
             <%= f.label :email, t(:email_address_label).html_safe, class: "col-xs-2 control-label" %>
             <div class="col-xs-10">
               <%= f.email_field :email, placeholder: t(:email_address_placeholder).html_safe, class: "form-control" %>
@@ -41,14 +41,14 @@
           </div>
 
 
-          <div class="form-group <%= 'has-error' if @message.errors.present? %>">
+          <div class="form-group <%= 'has-error' if @message.errors.include?(:subject) %>">
             <%= f.label :subject, t(:email_subject_label).html_safe, class: "col-xs-2 control-label" %>
             <div class="col-xs-10">
               <%= f.text_field :subject, placeholder: t(:email_subject_placeholder).html_safe, class: "form-control" %>
             </div>
           </div>
 
-          <div class="form-group <%= 'has-error' if @message.errors.present? %>">
+          <div class="form-group <%= 'has-error' if @message.errors.include?(:body) %>">
             <%= f.label :body, t(:email_body_label).html_safe, class: "col-xs-2 control-label" %>
             <div class="col-xs-10">
               <%= f.text_area :body, placeholder: t(:email_body_placeholder).html_safe, as: :text, rows: 10, class: "form-control" %>


### PR DESCRIPTION
Just changed the .present? to a .include? with the name of the field so if the message has an error it will only highlight the fields that have an error.

Sorry its such a small fix. Thats only only thing I can see that is a problem right now.

![screen shot 2013-11-29 at 10 40 15 am](https://f.cloud.github.com/assets/4175592/1646570/4be3e4f2-591f-11e3-9982-b9eeddccbf13.png)
